### PR TITLE
`/novel/[novelId]`の大まかな内容を作成

### DIFF
--- a/client/pages/novel/[novelId].module.css
+++ b/client/pages/novel/[novelId].module.css
@@ -1,0 +1,5 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/client/pages/novel/[novelId].module.css
+++ b/client/pages/novel/[novelId].module.css
@@ -1,5 +1,6 @@
-.container {
+.loading {
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 100svh;
 }

--- a/client/pages/novel/[novelId].module.css
+++ b/client/pages/novel/[novelId].module.css
@@ -4,3 +4,73 @@
   justify-content: center;
   min-height: 100svh;
 }
+
+.container {
+  display: flex;
+  gap: 4svmin;
+  align-items: center;
+  height: 100svh;
+  padding: 4svmin max(4svmin, 50svw - 64svmin);
+}
+
+.image {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 2svmin;
+  width: 100%;
+  height: fit-content;
+  overflow: hidden;
+}
+
+.image > img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 2svmin;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 4svmin;
+  width: 100%;
+  max-height: 64svh;
+  padding-top: 1lh;
+  padding-bottom: calc(64svh - 1lh);
+  overflow: hidden scroll;
+  line-height: 2rem;
+  letter-spacing: 0;
+}
+
+.content p {
+  text-indent: 1rem;
+}
+
+@media screen and (aspect-ratio <= 3 / 4) {
+  .container {
+    flex-direction: column;
+    gap: 8svmin;
+  }
+
+  .image {
+    flex-direction: column-reverse;
+    flex-shrink: 0;
+  }
+
+  .image > hgroup {
+    font-size: 0.8em;
+  }
+
+  .image > hgroup > h1 {
+    font-size: 1.6em;
+  }
+
+  .content {
+    max-height: none;
+    padding: 0 1lh 0 calc(100svw - 8svmin - 1lh);
+    overflow: scroll hidden;
+    writing-mode: vertical-rl;
+  }
+}

--- a/client/pages/novel/[novelId].page.tsx
+++ b/client/pages/novel/[novelId].page.tsx
@@ -1,6 +1,7 @@
 import type { NovelBodyEntity } from 'api/@types/novel';
 import { useCatchApiErr } from 'hooks/useCatchApiErr';
 import { useRouter } from 'next/router';
+import type { UIEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { apiClient } from 'utils/apiClient';
 import styles from './[novelId].module.css';
@@ -8,6 +9,7 @@ import styles from './[novelId].module.css';
 const Home = () => {
   const [novelBody, setNovelBody] = useState<NovelBodyEntity | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [readingParagraph, setReadingParagraph] = useState(0);
   const router = useRouter();
   const catchApiErr = useCatchApiErr();
 
@@ -17,6 +19,22 @@ const Home = () => {
     const novelIdParam = router.query.novelId;
     return Array.isArray(novelIdParam) ? novelIdParam[0] : novelIdParam ?? '';
   }, [router.query.novelId]);
+
+  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+    const target = e.currentTarget as HTMLDivElement;
+    const children = target.children;
+    const containerPosition = target.getBoundingClientRect();
+
+    const readingParagraphVertical = Array.from(children).findIndex(
+      (child) => child.getBoundingClientRect().top >= containerPosition.top,
+    );
+    const readingParagraphHorizontal = Array.from(children).findIndex(
+      (child) => child.getBoundingClientRect().right <= containerPosition.right,
+    );
+    const readingParagraph = Math.max(readingParagraphVertical, readingParagraphHorizontal);
+
+    setReadingParagraph(readingParagraph);
+  };
 
   useEffect(() => {
     setIsLoading(true);
@@ -33,13 +51,24 @@ const Home = () => {
     return () => setNovelBody(null);
   }, [novelId, catchApiErr]);
 
-  if (isLoading) return <div className={styles.loading}>Loading...</div>;
+  if (isLoading || novelBody === null) return <div className={styles.loading}>Loading...</div>;
 
   return (
-    <div>
-      <h1>Sakuga AI</h1>
-      <h2>Novel</h2>
-      <p>Novel ID: {novelId}</p>
+    <div className={styles.container}>
+      <div className={styles.image}>
+        <hgroup>
+          <h1>{novelBody.title}</h1>
+          <p>{novelBody.authorName}</p>
+        </hgroup>
+        <img src={novelBody.paragraphs[readingParagraph]?.imageUrl} alt="" />
+      </div>
+      <div className={styles.content} onScroll={handleScroll}>
+        {novelBody.paragraphs.map((paragraph, index) => (
+          <div key={index}>
+            <p>{paragraph.content}</p>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/client/pages/novel/[novelId].page.tsx
+++ b/client/pages/novel/[novelId].page.tsx
@@ -33,7 +33,7 @@ const Home = () => {
     return () => setNovelBody(null);
   }, [novelId, catchApiErr]);
 
-  if (isLoading) return <div className={styles.container}>Loading...</div>;
+  if (isLoading) return <div className={styles.loading}>Loading...</div>;
 
   return (
     <div>

--- a/client/pages/novel/[novelId].page.tsx
+++ b/client/pages/novel/[novelId].page.tsx
@@ -1,4 +1,5 @@
 import type { NovelBodyEntity } from 'api/@types/novel';
+import { useCatchApiErr } from 'hooks/useCatchApiErr';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import { apiClient } from 'utils/apiClient';
@@ -8,6 +9,7 @@ const Home = () => {
   const [novelBody, setNovelBody] = useState<NovelBodyEntity | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
+  const catchApiErr = useCatchApiErr();
 
   // `/novel/123234` -> `123234` のように、novelIdパラメータを取得
   // novelIdパラメータを取得し、それをもとに小説情報を取得する
@@ -25,10 +27,11 @@ const Home = () => {
 
     fetchNovelData()
       .then(setNovelBody)
+      .catch(catchApiErr)
       .finally(() => setIsLoading(false));
 
     return () => setNovelBody(null);
-  }, [novelId]);
+  }, [novelId, catchApiErr]);
 
   if (isLoading) return <div className={styles.container}>Loading...</div>;
 

--- a/client/pages/novel/[novelId].page.tsx
+++ b/client/pages/novel/[novelId].page.tsx
@@ -2,9 +2,11 @@ import type { NovelBodyEntity } from 'api/@types/novel';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import { apiClient } from 'utils/apiClient';
+import styles from './[novelId].module.css';
 
 const Home = () => {
-  const [novelBody, setNovelBody] = useState<NovelBodyEntity | null>(null)
+  const [novelBody, setNovelBody] = useState<NovelBodyEntity | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
 
   // `/novel/123234` -> `123234` のように、novelIdパラメータを取得
@@ -15,14 +17,20 @@ const Home = () => {
   }, [router.query.novelId]);
 
   useEffect(() => {
+    setIsLoading(true);
     const fetchNovelData = async () => {
       const res = await apiClient.novels.body.$get({ query: { id: novelId } });
-      return res
-    }
+      return res;
+    };
 
-    fetchNovelData().then(setNovelBody);
+    fetchNovelData()
+      .then(setNovelBody)
+      .finally(() => setIsLoading(false));
+
     return () => setNovelBody(null);
-  }, [novelId])
+  }, [novelId]);
+
+  if (isLoading) return <div className={styles.container}>Loading...</div>;
 
   return (
     <div>

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -23,6 +23,7 @@ a {
 
 ::-webkit-scrollbar {
   width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
## 概要

- `/novel/[novelId]`の内容を作成
  - api(`/novels/body?novelId`)から小説の情報を取得
  - 本文と画像を表示
  - 本文のスクロールに合わせて、画像を切り替え

## スクリーンショット

![image](https://github.com/ramy370612/Sakuga-AI/assets/131662659/ed4ef58f-1764-4404-9aef-39c18f3dddd8)

![image](https://github.com/ramy370612/Sakuga-AI/assets/131662659/e8b1eb9e-b13e-4970-88c9-4fc0a53d6c5b)

